### PR TITLE
Add elm.json dependency to lamdera/codecs

### DIFF
--- a/docs/3.0-upgrade-notes.md
+++ b/docs/3.0-upgrade-notes.md
@@ -1,5 +1,9 @@
 # 3.0 Upgrade Notes
 
+## elm.json
+
+- Add dependency `"lamdera/codecs": "1.0.0"`
+
 ## File Structure
 
 - `rm -rf .elm-pages`


### PR DESCRIPTION
Without this dependency compilation fails with error

```
>   Map.!: given key is not an element in the map
>   CallStack (from HasCallStack):
>     error, called at libraries/containers/containers/src/Data/Map/Internal.hs:627:17 in containers-0.6.2.1:Data.Map.Internal

```