### PR TITLE
Pipe operators for form scaffolding

### DIFF
--- a/src/Scaffold/Form.elm
+++ b/src/Scaffold/Form.elm
@@ -15,6 +15,7 @@ import Cli.Option
 import Elm
 import Elm.Annotation as Type
 import Elm.Declare
+import Elm.Op
 import List.Extra
 import Result.Extra
 
@@ -59,38 +60,40 @@ formWithFields elmCssView fields viewFn =
                 |> List.foldl
                     (\( fieldName, kind ) chain ->
                         chain
-                            |> formField fieldName
-                                (case kind of
-                                    FieldText ->
-                                        formFieldText
-                                            |> formFieldRequired (Elm.string "Required")
+                            |> Elm.Op.pipe
+                                (formField fieldName
+                                    (case kind of
+                                        FieldText ->
+                                            formFieldText
+                                                |> formFieldRequired (Elm.string "Required")
 
-                                    FieldInt ->
-                                        formFieldInt { invalid = \_ -> Elm.string "" }
-                                            |> formFieldRequired (Elm.string "Required")
+                                        FieldInt ->
+                                            formFieldInt { invalid = \_ -> Elm.string "" }
+                                                |> formFieldRequired (Elm.string "Required")
 
-                                    FieldTextarea ->
-                                        formFieldText
-                                            |> formFieldRequired (Elm.string "Required")
-                                            |> formFieldTextarea
-                                                { rows = Elm.nothing
-                                                , cols = Elm.nothing
-                                                }
+                                        FieldTextarea ->
+                                            formFieldText
+                                                |> formFieldRequired (Elm.string "Required")
+                                                |> formFieldTextarea
+                                                    { rows = Elm.nothing
+                                                    , cols = Elm.nothing
+                                                    }
 
-                                    FieldFloat ->
-                                        formFieldFloat { invalid = \_ -> Elm.string "" }
-                                            |> formFieldRequired (Elm.string "Required")
+                                        FieldFloat ->
+                                            formFieldFloat { invalid = \_ -> Elm.string "" }
+                                                |> formFieldRequired (Elm.string "Required")
 
-                                    FieldTime ->
-                                        formFieldTime { invalid = \_ -> Elm.string "" }
-                                            |> formFieldRequired (Elm.string "Required")
+                                        FieldTime ->
+                                            formFieldTime { invalid = \_ -> Elm.string "" }
+                                                |> formFieldRequired (Elm.string "Required")
 
-                                    FieldDate ->
-                                        formFieldDate { invalid = \_ -> Elm.string "" }
-                                            |> formFieldRequired (Elm.string "Required")
+                                        FieldDate ->
+                                            formFieldDate { invalid = \_ -> Elm.string "" }
+                                                |> formFieldRequired (Elm.string "Required")
 
-                                    FieldCheckbox ->
-                                        formFieldCheckbox
+                                        FieldCheckbox ->
+                                            formFieldCheckbox
+                                    )
                                 )
                     )
                     (formInit
@@ -102,7 +105,7 @@ formWithFields elmCssView fields viewFn =
                                             |> List.foldl
                                                 (\fieldExpression chain ->
                                                     chain
-                                                        |> validationAndMap fieldExpression
+                                                        |> Elm.Op.pipe (validationAndMap fieldExpression)
                                                 )
                                                 (validationSucceed (Elm.val "ParsedForm"))
                                       )
@@ -295,8 +298,8 @@ provide { fields, view, elmCssView } =
             }
 
 
-validationAndMap : Elm.Expression -> Elm.Expression -> Elm.Expression
-validationAndMap andMapArg andMapArg0 =
+validationAndMap : Elm.Expression -> Elm.Expression
+validationAndMap andMapArg =
     Elm.apply
         (Elm.value
             { importFrom = [ "Form", "Validation" ]
@@ -304,7 +307,7 @@ validationAndMap andMapArg andMapArg0 =
             , annotation = Nothing
             }
         )
-        [ andMapArg, andMapArg0 ]
+        [ andMapArg ]
 
 
 validationSucceed : Elm.Expression -> Elm.Expression
@@ -438,8 +441,8 @@ formFieldFloat floatArg =
         ]
 
 
-formField : String -> Elm.Expression -> Elm.Expression -> Elm.Expression
-formField fieldArg fieldArg0 fieldArg1 =
+formField : String -> Elm.Expression -> Elm.Expression
+formField fieldArg fieldArg0 =
     Elm.apply
         (Elm.value
             { importFrom = [ "Form" ]
@@ -447,7 +450,7 @@ formField fieldArg fieldArg0 fieldArg1 =
             , annotation = Nothing
             }
         )
-        [ Elm.string fieldArg, fieldArg0, fieldArg1 ]
+        [ Elm.string fieldArg, fieldArg0 ]
 
 
 formInit : Elm.Expression -> Elm.Expression


### PR DESCRIPTION
I was watching the elm-pages blog engine demo, and found the part where you scaffolded the `Admin.Slug_` page, and mentioned that elm-codegen couldn't create pipelines, so you were using functionality from your IDE to convert the code to use pipelines and make it more readable.

It happens that there is a way to use pipelines, although it's a little weird, and we lose some type information in the generation code. Because we lose a little bit of type information in the generation code, it's totally fine if you don't want this PR! It's just an idea. I'm not sure it's worth it to sacrifice type information in the codegen code in order to provide a more readable code to the end user.

This PR basically makes the generated code for scaffolded forms look like the one you had after transforming it with your IDE. Either way, here's a sample that would be generated with all of the possible form types (ignore the `view` function, I haven't messed with it, and just used some dummy value to print it in the repl):

```elm
form : Form.HtmlForm String ParsedForm input Msg
form =
    (\\int text textarea float time date checkbox ->
         { combine =
             ParsedForm
                 |> Form.Validation.succeed -- Maybe `Form.Validation.succeed ParsedForm |> ...` is better?
                 |> Form.Validation.andMap int
                 |> Form.Validation.andMap text
                 |> Form.Validation.andMap textarea
                 |> Form.Validation.andMap float
                 |> Form.Validation.andMap time
                 |> Form.Validation.andMap date
                 |> Form.Validation.andMap checkbox
         , view = \\formState -> "viewFn"
         }
    )
        |> Form.init
        |> Form.hiddenKind ( "kind", "regular" ) "Expected kind."
        |> Form.field
            "int"
            (Form.Field.int { invalid = \\intUnpack -> "" }
                |> Form.Field.required "Required"
            )
        |> Form.field "text" (Form.Field.required "Required" Form.Field.text) -- `text` is special because it doesn't take any arguments. We could also use the pipe here, like so: `Form.Field.text |> Form.Field.required "Required"`
        |> Form.field
            "textarea"
            (Form.Field.text
                |> Form.Field.required "Required"
                |> Form.Field.textarea { rows = Nothing, cols = Nothing }
            )
        |> Form.field
            "float"
            (Form.Field.float { invalid = \\floatUnpack -> "" }
                |> Form.Field.required "Required"
            )
        |> Form.field
            "time"
            (Form.Field.time { invalid = \\timeUnpack -> "" }
                |> Form.Field.required "Required"
            )
        |> Form.field
            "date"
            (Form.Field.date { invalid = \\dateUnpack -> "" }
                |> Form.Field.required "Required"
            )
        |> Form.field "checkbox" Form.Field.checkbox
```

If the pipeline inside the field definition (e.g. `Form.Field.data ... |> Form.Field.required "Required`) feels too pipe-y, we could also not use pipes there